### PR TITLE
Fix the ordering of bytes in pitch bend commands

### DIFF
--- a/docs/midi-pitch-bend.md
+++ b/docs/midi-pitch-bend.md
@@ -11,22 +11,22 @@ midiCommand(0x90, pitch, velocity);
 Then to bend the pitch on channel 0, you send a pitch bend message like this:
 
 ````
-midiCommand(0xE0, msb, lsb);
+midiCommand(0xE0, lsb, msb);
 ````
 
-`msb` and `lsb` are the most significant byte and least significant byte of a 14-bit number. Note that most computers store numbers as 8-bit numbers, so you'll need to [convert the bytes](midi-bit-shifting.md) before you send them.  
+`lsb` and `msb` are the least significant byte and most significant byte of a 14-bit number. Note that most computers store numbers as 8-bit numbers, so you'll need to [convert the bytes](midi-bit-shifting.md) before you send them.  
 
 Pitch bend can bend up or down. Most synthesizers will bend up to +/-2 semitones. So max pitch bend down takes the note down two semitones. Max pitch bend up takes it up two semitones. A pitch bend value of 8192 represents no pitch bend. For example, if you want a pitch between C4 and C#4, you would play C4, then pitch bend up a little. For example:
 
 ````
 midiCommand(0x90, 60, 127);  // play C4 as loud as possible
-midiCommand(0xE0, 64, 39);  // a little pitch bend up
+midiCommand(0xE0, 39, 64);  // a little pitch bend up
 ````
 Or to play between C4 and B3, the note below it, you would pitch bend down:
 
 ````
 midiCommand(0x90, 60, 127);  // play C4 as loud as possible
-midiCommand(0xE0, 63, 100);  // a little pitch bend down
+midiCommand(0xE0, 100, 63);  // a little pitch bend down
 ````
 How do you get the pitch bend values? Pitch bend has a 14-bit range, from 0 - 16383. The two data bytes combined make the pitch bend value. A pitch bend of 0 bends 2 semitones down, while 16383 bends almost 2 semitones up. In other words, C4 plus pitch bend of 16383 is D4, and C4 plus pitch bend of 0 is Bb3.  
 


### PR DESCRIPTION
I found your page while looking for a description on pitch bending for MIDI while I was writing a control script for my Launchpad X to be used with Bitwig Studio, and found this article really helpful, but spent quite a while figuring out why it was working in an unexpected way. As it turns out, the order of the significance of the bytes were reversed. :upside_down_face: 
(References: https://www.midi.org/specifications-old/item/table-1-summary-of-midi-message and https://www.cs.cmu.edu/~music/cmsip/readings/davids-midi-spec.htm)

Thank you very much for sharing such educational content, I hope that you'll manage to merge my fix to avoid confusing others that might stumble upon this. :wink: